### PR TITLE
ModelDefinition (<model>) did not define the name

### DIFF
--- a/smdx/smdx.xsd
+++ b/smdx/smdx.xsd
@@ -35,6 +35,7 @@ This document may be used, copied, and furnished to others, without restrictions
     </xs:sequence>
     <xs:attribute name="id" type="xs:integer" />
     <xs:attribute name="len" type="xs:integer" />
+    <xs:attribute name="name" type="xs:string" />
   </xs:complexType>
 
   <xs:complexType name="BlockDefinition">


### PR DESCRIPTION
The ModelDefinition was lacking a name attribute that was used in all specifications I checked. Since this is the only place where the name is defined as far as I could see I decided to propose this correction
